### PR TITLE
Added tests and made some minor fixes according

### DIFF
--- a/ast/src/test/kotlin/ASTTestHashCodeEquals.kt
+++ b/ast/src/test/kotlin/ASTTestHashCodeEquals.kt
@@ -1,0 +1,130 @@
+import ast.AssignmentStatement
+import ast.BooleanCondition
+import ast.Call
+import ast.ConstantDeclaration
+import ast.DeclarationStatement
+import ast.IfAndElseStatement
+import ast.IfStatement
+import ast.LiteralArgument
+import ast.MethodResult
+import ast.Range
+import ast.Scope
+import ast.VariableArgument
+import ast.VariableDeclaration
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ASTTestHashCodeEquals {
+    @Test
+    fun `test hashCode of Range`() {
+        val range1 = Range(1, 2)
+        val range2 = Range(1, 2)
+        assertEquals(range1.hashCode(), range2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of Scope`() {
+        val scope1 = Scope("program", Range(0, 2), emptyList())
+        val scope2 = Scope("program", Range(0, 2), emptyList())
+        assertEquals(scope1.hashCode(), scope2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of Call`() {
+        val call1 = Call(Range(4, 6), "someMethod", emptyList())
+        val call2 = Call(Range(4, 6), "someMethod", emptyList())
+        assertEquals(call1.hashCode(), call2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of VariableDeclaration`() {
+        val varDecl1 = VariableDeclaration(Range(7, 9), "variable1", "Int", LiteralArgument(Range(8, 8), "10", "Int"))
+        val varDecl2 = VariableDeclaration(Range(7, 9), "variable1", "Int", LiteralArgument(Range(8, 8), "10", "Int"))
+        assertEquals(varDecl1.hashCode(), varDecl2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of ConstantDeclaration`() {
+        val constDecl1 = ConstantDeclaration(Range(10, 12), "constant1", "String", LiteralArgument(Range(11, 11), "\"Hello\"", "String"))
+        val constDecl2 = ConstantDeclaration(Range(10, 12), "constant1", "String", LiteralArgument(Range(11, 11), "\"Hello\"", "String"))
+        assertEquals(constDecl1.hashCode(), constDecl2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of LiteralArgument`() {
+        val literalArg1 = LiteralArgument(Range(13, 13), "true", "Boolean")
+        val literalArg2 = LiteralArgument(Range(13, 13), "true", "Boolean")
+        assertEquals(literalArg1.hashCode(), literalArg2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of VariableArgument`() {
+        val varArg1 = VariableArgument(Range(14, 14), "variable2")
+        val varArg2 = VariableArgument(Range(14, 14), "variable2")
+        assertEquals(varArg1.hashCode(), varArg2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of MethodResult`() {
+        val methodResult1 = MethodResult(Range(15, 17), Call(Range(16, 17), "getResult", emptyList()))
+        val methodResult2 = MethodResult(Range(15, 17), Call(Range(16, 17), "getResult", emptyList()))
+        assertEquals(methodResult1.hashCode(), methodResult2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of DeclarationStatement`() {
+        val declStmt1 = DeclarationStatement(Range(18, 20), "variable3", "Double")
+        val declStmt2 = DeclarationStatement(Range(18, 20), "variable3", "Double")
+        assertEquals(declStmt1.hashCode(), declStmt2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of AssignmentStatement`() {
+        val assignStmt1 = AssignmentStatement(Range(21, 23), "variable4", LiteralArgument(Range(22, 22), "7", "Int"))
+        val assignStmt2 = AssignmentStatement(Range(21, 23), "variable4", LiteralArgument(Range(22, 22), "7", "Int"))
+        assertEquals(assignStmt1.hashCode(), assignStmt2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of BooleanCondition`() {
+        val booleanCond1 = BooleanCondition(Range(25, 25), LiteralArgument(Range(25, 25), "true", "Boolean"))
+        val booleanCond2 = BooleanCondition(Range(25, 25), LiteralArgument(Range(25, 25), "true", "Boolean"))
+        assertEquals(booleanCond1.hashCode(), booleanCond2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of IfStatement`() {
+        val ifStmt1 =
+            IfStatement(
+                Range(24, 26),
+                listOf(BooleanCondition(Range(25, 25), LiteralArgument(Range(25, 25), "true", "Boolean"))),
+                Scope("ifScope", Range(26, 26), emptyList()),
+            )
+        val ifStmt2 =
+            IfStatement(
+                Range(24, 26),
+                listOf(BooleanCondition(Range(25, 25), LiteralArgument(Range(25, 25), "true", "Boolean"))),
+                Scope("ifScope", Range(26, 26), emptyList()),
+            )
+        assertEquals(ifStmt1.hashCode(), ifStmt2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode of IfAndElseStatement`() {
+        val ifElseStmt1 =
+            IfAndElseStatement(
+                Range(27, 29),
+                listOf(BooleanCondition(Range(28, 28), LiteralArgument(Range(28, 28), "false", "Boolean"))),
+                Scope("ifScope", Range(29, 29), emptyList()),
+                Scope("elseScope", Range(29, 29), emptyList()),
+            )
+        val ifElseStmt2 =
+            IfAndElseStatement(
+                Range(27, 29),
+                listOf(BooleanCondition(Range(28, 28), LiteralArgument(Range(28, 28), "false", "Boolean"))),
+                Scope("ifScope", Range(29, 29), emptyList()),
+                Scope("elseScope", Range(29, 29), emptyList()),
+            )
+        assertEquals(ifElseStmt1.hashCode(), ifElseStmt2.hashCode())
+    }
+}

--- a/ast/src/test/kotlin/ASTTestHashCodeNotEquals.kt
+++ b/ast/src/test/kotlin/ASTTestHashCodeNotEquals.kt
@@ -1,0 +1,123 @@
+import ast.BooleanCondition
+import ast.Call
+import ast.IfAndElseStatement
+import ast.IfStatement
+import ast.LiteralArgument
+import ast.Range
+import ast.Scope
+import ast.VariableDeclaration
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class ASTTestHashCodeNotEquals {
+    @Test
+    fun `test hashCode inequality of Range`() {
+        val range1 = Range(1, 2)
+        val range2 = Range(2, 3)
+        assertNotEquals(range1.hashCode(), range2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode inequality of Scope`() {
+        val scope1 = Scope("program", Range(0, 2), emptyList())
+        val scope2 = Scope("function", Range(0, 2), emptyList())
+        assertNotEquals(scope1.hashCode(), scope2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode inequality of Call`() {
+        val call1 = Call(Range(4, 6), "someMethod", emptyList())
+        val call2 = Call(Range(4, 6), "anotherMethod", emptyList())
+        assertNotEquals(call1.hashCode(), call2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode inequality of VariableDeclaration`() {
+        val varDecl1 =
+            VariableDeclaration(
+                Range(7, 9),
+                "variable1",
+                "Int",
+                LiteralArgument(Range(8, 8), "10", "Int"),
+            )
+        val varDecl2 =
+            VariableDeclaration(
+                Range(7, 9),
+                "variable2",
+                "Double",
+                LiteralArgument(Range(8, 8), "10", "Int"),
+            )
+        assertNotEquals(varDecl1.hashCode(), varDecl2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode inequality of LiteralArgument`() {
+        val literalArg1 = LiteralArgument(Range(13, 13), "true", "Boolean")
+        val literalArg2 = LiteralArgument(Range(13, 13), "false", "Boolean")
+        assertNotEquals(literalArg1.hashCode(), literalArg2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode inequality of IfStatement`() {
+        val ifStmt1 =
+            IfStatement(
+                Range(24, 26),
+                listOf(
+                    BooleanCondition(
+                        Range(25, 25),
+                        LiteralArgument(Range(25, 25), "true", "Boolean"),
+                    ),
+                ),
+                Scope("ifScope", Range(26, 26), emptyList()),
+            )
+        val ifStmt2 =
+            IfStatement(
+                Range(24, 26),
+                listOf(
+                    BooleanCondition(
+                        Range(25, 25),
+                        LiteralArgument(Range(25, 25), "false", "Boolean"),
+                    ),
+                ),
+                Scope("ifScope", Range(26, 26), emptyList()),
+            )
+        assertNotEquals(ifStmt1.hashCode(), ifStmt2.hashCode())
+    }
+
+    @Test
+    fun `test hashCode inequality of IfAndElseStatement`() {
+        val ifElseStmt1 =
+            IfAndElseStatement(
+                Range(27, 29),
+                listOf(
+                    BooleanCondition(
+                        Range(28, 28),
+                        LiteralArgument(Range(28, 28), "false", "Boolean"),
+                    ),
+                ),
+                Scope("ifScope", Range(29, 29), emptyList()),
+                Scope("elseScope", Range(29, 29), emptyList()),
+            )
+        val ifElseStmt2 =
+            IfAndElseStatement(
+                Range(27, 29),
+                listOf(
+                    BooleanCondition(
+                        Range(28, 28),
+                        LiteralArgument(
+                            Range(28, 28),
+                            "true",
+                            "Boolean",
+                        ),
+                    ),
+                ),
+                Scope(
+                    "ifScope",
+                    Range(29, 29),
+                    emptyList(),
+                ),
+                Scope("elseScope", Range(29, 29), emptyList()),
+            )
+        assertNotEquals(ifElseStmt1.hashCode(), ifElseStmt2.hashCode())
+    }
+}

--- a/ast/src/test/kotlin/ASTTestToString.kt
+++ b/ast/src/test/kotlin/ASTTestToString.kt
@@ -1,0 +1,162 @@
+import ast.AssignmentStatement
+import ast.BooleanCondition
+import ast.Call
+import ast.ConstantDeclaration
+import ast.DeclarationStatement
+import ast.IfAndElseStatement
+import ast.IfStatement
+import ast.LiteralArgument
+import ast.MethodResult
+import ast.Range
+import ast.Scope
+import ast.VariableArgument
+import ast.VariableDeclaration
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ASTTestToString {
+    @Test
+    fun `test toString of Range`() {
+        val range = Range(1, 2)
+        assertEquals("Range(start=1, end=2)", range.toString())
+    }
+
+    @Test
+    fun `test toString of Scope`() {
+        val scope = Scope("program", Range(0, 2), emptyList())
+        assertEquals("Scope(type='program', range=Range(start=0, end=2), body=[])", scope.toString())
+    }
+
+    @Test
+    fun `test toString of BooleanCondition`() {
+        val booleanCond = BooleanCondition(Range(3, 3), VariableArgument(Range(3, 3), "a"))
+        assertEquals(
+            "BooleanCondition(range=Range(start=3, end=3)," +
+                " argument=VariableArgument(range=Range(start=3, end=3), name='a'))",
+            booleanCond.toString(),
+        )
+    }
+
+    @Test
+    fun `test toString of Call`() {
+        val call = Call(Range(4, 6), "someMethod", listOf(VariableArgument(Range(4, 4), "arg1"), LiteralArgument(Range(5, 5), "5", "Int")))
+        assertEquals(
+            "Call(range=Range(start=4, end=6), name='someMethod'," +
+                " arguments=[VariableArgument(range=Range(start=4, end=4), name='arg1')," +
+                " LiteralArgument(range=Range(start=5, end=5), value='5', type='Int')])",
+            call.toString(),
+        )
+    }
+
+    @Test
+    fun `test toString of VariableDeclaration`() {
+        val varDecl = VariableDeclaration(Range(7, 9), "variable1", "Int", LiteralArgument(Range(8, 8), "10", "Int"))
+        assertEquals(
+            "VariableDeclaration(range=Range(start=7, end=9)," +
+                " variableName='variable1', variableType='Int'," +
+                " value=LiteralArgument(range=Range(start=8, end=8)," +
+                " value='10', type='Int'))",
+            varDecl.toString(),
+        )
+    }
+
+    @Test
+    fun `test toString of ConstantDeclaration`() {
+        val constDecl = ConstantDeclaration(Range(10, 12), "constant1", "String", LiteralArgument(Range(11, 11), "\"Hello\"", "String"))
+        assertEquals(
+            "ConstantDeclaration(range=Range(start=10, end=12)," +
+                " variableName='constant1', variableType='String'," +
+                " value=LiteralArgument(range=Range(start=11, end=11)," +
+                " value='\"Hello\"', type='String'))",
+            constDecl.toString(),
+        )
+    }
+
+    @Test
+    fun `test toString of LiteralArgument`() {
+        val literalArg = LiteralArgument(Range(13, 13), "true", "Boolean")
+        assertEquals(
+            "LiteralArgument(range=Range(start=13, end=13), value='true', type='Boolean')",
+            literalArg.toString(),
+        )
+    }
+
+    @Test
+    fun `test toString of VariableArgument`() {
+        val varArg = VariableArgument(Range(14, 14), "variable2")
+        assertEquals("VariableArgument(range=Range(start=14, end=14), name='variable2')", varArg.toString())
+    }
+
+    @Test
+    fun `test toString of MethodResult`() {
+        val methodResult = MethodResult(Range(15, 17), Call(Range(16, 17), "getResult", emptyList()))
+        assertEquals(
+            "MethodResult(range=Range(start=15, end=17)," +
+                " methodCall=Call(range=Range(start=16, end=17)," +
+                " name='getResult', arguments=[]))",
+            methodResult.toString(),
+        )
+    }
+
+    @Test
+    fun `test toString of DeclarationStatement`() {
+        val declStmt = DeclarationStatement(Range(18, 20), "variable3", "Double")
+        assertEquals(
+            "DeclarationStatement(range=Range(start=18, end=20)," +
+                " variableName='variable3', variableType='Double')",
+            declStmt.toString(),
+        )
+    }
+
+    @Test
+    fun `test toString of AssignmentStatement`() {
+        val assignStmt = AssignmentStatement(Range(21, 23), "variable4", LiteralArgument(Range(22, 22), "7", "Int"))
+        assertEquals(
+            "AssignmentStatement(range=Range(start=21, end=23)," +
+                " variableName='variable4'," +
+                " value=LiteralArgument(range=Range(start=22, end=22)," +
+                " value='7', type='Int'))",
+            assignStmt.toString(),
+        )
+    }
+
+    @Test
+    fun `test toString of IfStatement`() {
+        val ifStmt =
+            IfStatement(
+                Range(24, 26),
+                listOf(BooleanCondition(Range(25, 25), LiteralArgument(Range(25, 25), "true", "Boolean"))),
+                Scope("ifScope", Range(26, 26), emptyList()),
+            )
+        assertEquals(
+            "IfStatement(range=Range(start=24, end=26)," +
+                " conditions=[BooleanCondition(range=Range(start=25, end=25)," +
+                " argument=LiteralArgument(range=Range(start=25, end=25)," +
+                " value='true', type='Boolean'))]," +
+                " scope=Scope(type='ifScope', range=Range(start=26, end=26)," +
+                " body=[]))",
+            ifStmt.toString(),
+        )
+    }
+
+    @Test
+    fun `test toString of IfAndElseStatement`() {
+        val ifElseStmt =
+            IfAndElseStatement(
+                Range(27, 29),
+                listOf(BooleanCondition(Range(28, 28), LiteralArgument(Range(28, 28), "false", "Boolean"))),
+                Scope("ifScope", Range(29, 29), emptyList()),
+                Scope("elseScope", Range(29, 29), emptyList()),
+            )
+        assertEquals(
+            "IfAndElseStatement(range=Range(start=27, end=29), " +
+                "conditions=[BooleanCondition(range=Range(start=28, end=28), " +
+                "argument=LiteralArgument(range=Range(start=28, end=28), value='false', type='Boolean'))], " +
+                "ifScope=Scope(type='ifScope', range=Range(start=29, end=29), body=[]), " +
+                "elseScope=Scope(type='elseScope', range=Range(start=29, end=29), body=[]))",
+            ifElseStmt.toString(),
+        )
+    }
+
+    // Add more tests for other classes as needed
+}

--- a/formatter/src/main/kotlin/formater/configurationReader/JsonConfigurationReader.kt
+++ b/formatter/src/main/kotlin/formater/configurationReader/JsonConfigurationReader.kt
@@ -81,13 +81,13 @@ object JsonConfigurationReader : IConfigurationReader {
                 if (jsonFieldIndentation != null) {
                     try {
                         val indentationAux = jsonFieldIndentation.asInt
-                        if (indentationAux < 0) {
-                            println("WARNING: indentation was not a positive value")
+                        if (indentationAux !in 0..8) {
+                            println("WARNING: indentation was not a value between 0 and 8 (inclusive)")
                         } else {
                             indentation = indentationAux
                         }
                     } catch (e: Exception) {
-                        println("WARNING: the field of indentation was not a int type")
+                        println("WARNING: the field of indentation was not an int type")
                     }
                 }
 

--- a/formatter/src/test/kotlin/formatter/JsonConfigReaderTest.kt
+++ b/formatter/src/test/kotlin/formatter/JsonConfigReaderTest.kt
@@ -1,0 +1,118 @@
+package formatter
+
+import formater.configurationReader.JsonConfigurationReader
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class JsonConfigReaderTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `test001 getFileExtension`() {
+        assertEquals("json", JsonConfigurationReader.getFileExtension())
+    }
+
+    @Test
+    fun `test002 readFileAndBuildRules with valid json file`() {
+        val jsonContent =
+            """
+            {
+                "spaceBeforeColon": false,
+                "spaceAfterColon": false,
+                "spaceBeforeAndAfterEqual": false,
+                "lineJumpBeforePrintln": 2,
+                "indentation": 2
+            }
+            """.trimIndent()
+        val configFile = File(tempDir, "config.json")
+        configFile.writeText(jsonContent)
+
+        val result = JsonConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid FormatterConfiguration")
+
+        assertEquals(false, config.spaceBeforeColon)
+        assertEquals(false, config.spaceAfterColon)
+        assertEquals(false, config.spaceBeforeAndAfterEqual)
+        assertEquals(2, config.lineJumpBeforePrintln)
+        assertEquals(2, config.indentation)
+    }
+
+    @Test
+    fun `test003 readFileAndBuildRules with missing values`() {
+        val jsonContent =
+            """
+            {
+                "spaceBeforeColon": false
+            }
+            """.trimIndent()
+        val configFile = File(tempDir, "config.json")
+        configFile.writeText(jsonContent)
+
+        val result = JsonConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid FormatterConfiguration")
+
+        assertEquals(false, config.spaceBeforeColon)
+        assertEquals(true, config.spaceAfterColon)
+        assertEquals(true, config.spaceBeforeAndAfterEqual)
+        assertEquals(1, config.lineJumpBeforePrintln)
+        assertEquals(4, config.indentation)
+    }
+
+    @Test
+    fun `test004 readFileAndBuildRules with invalid file extension`() {
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText("{}")
+
+        val result = JsonConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isFailure)
+        assertEquals("The method was expecting a json file but got a yaml", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `test005 readFileAndBuildRules with invalid lineJumpBeforePrintln value`() {
+        val jsonContent =
+            """
+            {
+                "lineJumpBeforePrintln": 5
+            }
+            """.trimIndent()
+        val configFile = File(tempDir, "config.json")
+        configFile.writeText(jsonContent)
+
+        val result = JsonConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid FormatterConfiguration")
+
+        assertEquals(1, config.lineJumpBeforePrintln)
+    }
+
+    @Test
+    fun `test006 readFileAndBuildRules with invalid indentation value`() {
+        val jsonContent =
+            """
+            {
+                "indentation": 10
+            }
+            """.trimIndent()
+        val configFile = File(tempDir, "config.json")
+        configFile.writeText(jsonContent)
+
+        val result = JsonConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid FormatterConfiguration")
+
+        assertEquals(4, config.indentation)
+    }
+}

--- a/formatter/src/test/kotlin/formatter/YamlConfigReaderTest.kt
+++ b/formatter/src/test/kotlin/formatter/YamlConfigReaderTest.kt
@@ -1,0 +1,110 @@
+package formatter
+
+import formater.configurationReader.YamlConfigurationReader
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class YamlConfigReaderTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `test getFileExtension`() {
+        assertEquals("yaml", YamlConfigurationReader.getFileExtension())
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with valid yaml file`() {
+        val yamlContent =
+            """
+            spaceBeforeColon: false
+            spaceAfterColon: false
+            spaceBeforeAndAfterEqual: false
+            lineJumpBeforePrintln: 2
+            indentation: 2
+            """.trimIndent()
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText(yamlContent)
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid FormatterConfiguration")
+
+        assertEquals(false, config.spaceBeforeColon)
+        assertEquals(false, config.spaceAfterColon)
+        assertEquals(false, config.spaceBeforeAndAfterEqual)
+        assertEquals(2, config.lineJumpBeforePrintln)
+        assertEquals(2, config.indentation)
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with missing values`() {
+        val yamlContent =
+            """
+            spaceBeforeColon: false
+            """.trimIndent()
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText(yamlContent)
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid FormatterConfiguration")
+
+        assertEquals(false, config.spaceBeforeColon)
+        assertEquals(true, config.spaceAfterColon)
+        assertEquals(true, config.spaceBeforeAndAfterEqual)
+        assertEquals(1, config.lineJumpBeforePrintln)
+        assertEquals(4, config.indentation)
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with invalid file extension`() {
+        val configFile = File(tempDir, "config.json")
+        configFile.writeText("{}")
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isFailure)
+        assertEquals("The method was expecting a json file but got a json", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with invalid lineJumpBeforePrintln value`() {
+        val yamlContent =
+            """
+            lineJumpBeforePrintln: 5
+            """.trimIndent()
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText(yamlContent)
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid FormatterConfiguration")
+
+        assertEquals(1, config.lineJumpBeforePrintln)
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with invalid indentation value`() {
+        val yamlContent =
+            """
+            indentation: 10
+            """.trimIndent()
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText(yamlContent)
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid FormatterConfiguration")
+
+        assertEquals(4, config.indentation)
+    }
+}

--- a/interpreter/src/main/kotlin/interpreter/specializedInterpreter/printscriptMethods/ReadEnv.kt
+++ b/interpreter/src/main/kotlin/interpreter/specializedInterpreter/printscriptMethods/ReadEnv.kt
@@ -23,7 +23,7 @@ object ReadEnv : PrintScriptMethod {
         if (argInterpretation.data == null) {
             return ComposedResult(
                 null,
-                argInterpretation.interpreter.reportError("readEnv requires at list one value on ${sentence.range}"),
+                argInterpretation.interpreter.reportError("readEnv requires at least one value on ${sentence.range}"),
             )
         }
 

--- a/linter/src/main/kotlin/result/validation/ValidResult.kt
+++ b/linter/src/main/kotlin/result/validation/ValidResult.kt
@@ -6,4 +6,8 @@ class ValidResult : ValidationResult {
         if (other !is ValidResult) return false
         return true
     }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
 }

--- a/linter/src/main/kotlin/result/validation/WarningResult.kt
+++ b/linter/src/main/kotlin/result/validation/WarningResult.kt
@@ -14,4 +14,10 @@ class WarningResult(val range: Range, val message: String) : ValidationResult {
 
         return true
     }
+
+    override fun hashCode(): Int {
+        var result = range.hashCode()
+        result = 31 * result + message.hashCode()
+        return result
+    }
 }

--- a/linter/src/test/kotlin/JsonConfigReaderTest.kt
+++ b/linter/src/test/kotlin/JsonConfigReaderTest.kt
@@ -1,0 +1,76 @@
+package configurationReader
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class JsonConfigReaderTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `test001 getFileExtension`() {
+        assertEquals("json", JsonConfigurationReader.getFileExtension())
+    }
+
+    @Test
+    fun `test002 readFileAndBuildRules with valid json file`() {
+        val jsonContent =
+            """
+            {
+                "camelCase": false,
+                "printlnWithoutExpression": false,
+                "undeclaredVariableStatement": false,
+                "readInputWithoutExpression": false
+            }
+            """.trimIndent()
+        val configFile = File(tempDir, "config.json")
+        configFile.writeText(jsonContent)
+
+        val result = JsonConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid LinterConfiguration")
+
+        assertEquals(false, config.camelCase)
+        assertEquals(false, config.printlnWithoutExpression)
+        assertEquals(false, config.undeclaredVariableStatement)
+        assertEquals(false, config.readInputWithoutExpression)
+    }
+
+    @Test
+    fun `test003 readFileAndBuildRules with missing values`() {
+        val jsonContent =
+            """
+            {
+                "camelCase": false
+            }
+            """.trimIndent()
+        val configFile = File(tempDir, "config.json")
+        configFile.writeText(jsonContent)
+
+        val result = JsonConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid LinterConfiguration")
+
+        assertEquals(false, config.camelCase)
+        assertEquals(true, config.printlnWithoutExpression)
+        assertEquals(true, config.undeclaredVariableStatement)
+        assertEquals(true, config.readInputWithoutExpression)
+    }
+
+    @Test
+    fun `test004 readFileAndBuildRules with invalid file extension`() {
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText("{}")
+
+        val result = JsonConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isFailure)
+        assertEquals("The method was expecting a json file but got a yaml", result.exceptionOrNull()?.message)
+    }
+}

--- a/linter/src/test/kotlin/ResultTest.kt
+++ b/linter/src/test/kotlin/ResultTest.kt
@@ -1,0 +1,36 @@
+import ast.Range
+import org.junit.jupiter.api.Test
+import result.validation.ValidResult
+import result.validation.WarningResult
+
+class ResultTest {
+    @Test
+    fun `test001 valid result Equals function`() {
+        val validResult1 = ValidResult()
+        val validResult2 = ValidResult()
+        val wariningResult = WarningResult(Range(1, 2), "message")
+        assert(validResult1.equals(validResult2))
+        assert(!validResult1.equals(wariningResult))
+    }
+
+    @Test
+    fun `test002 valid result HashCode function`() {
+        val validResult = ValidResult()
+        assert(validResult.hashCode() == validResult.javaClass.hashCode())
+    }
+
+    @Test
+    fun `test003 warning result Equals function`() {
+        val warningResult1 = WarningResult(Range(1, 2), "message")
+        val warningResult2 = WarningResult(Range(1, 2), "message")
+        val validResult = ValidResult()
+        assert(warningResult1.equals(warningResult2))
+        assert(!warningResult1.equals(validResult))
+    }
+
+    @Test
+    fun `test004 warning result HashCode function`() {
+        val warningResult = WarningResult(Range(1, 2), "message")
+        assert(warningResult.hashCode() == 31 * warningResult.range.hashCode() + warningResult.message.hashCode())
+    }
+}

--- a/linter/src/test/kotlin/YamlConfigReaderTest.kt
+++ b/linter/src/test/kotlin/YamlConfigReaderTest.kt
@@ -1,0 +1,140 @@
+package configurationReader
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class YamlConfigReaderTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `test getFileExtension`() {
+        assertEquals("yaml", YamlConfigurationReader.getFileExtension())
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with valid yaml file`() {
+        val yamlContent =
+            """
+            camelCase: false
+            printlnWithoutException: false
+            undeclaredVariableStatement: false
+            readInputWithoutExpression: false
+            """.trimIndent()
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText(yamlContent)
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid LinterConfiguration")
+
+        assertEquals(false, config.camelCase)
+        assertEquals(false, config.printlnWithoutExpression)
+        assertEquals(false, config.undeclaredVariableStatement)
+        assertEquals(false, config.readInputWithoutExpression)
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with missing values`() {
+        val yamlContent =
+            """
+            camelCase: false
+            """.trimIndent()
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText(yamlContent)
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid LinterConfiguration")
+
+        assertEquals(false, config.camelCase)
+        assertEquals(true, config.printlnWithoutExpression)
+        assertEquals(true, config.undeclaredVariableStatement)
+        assertEquals(true, config.readInputWithoutExpression)
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with invalid file extension`() {
+        val configFile = File(tempDir, "config.json")
+        configFile.writeText("{}")
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isFailure)
+        assertEquals("The method was expecting a yaml file but got a json", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with invalid camelCase value`() {
+        val yamlContent =
+            """
+            camelCase: "invalid"
+            """.trimIndent()
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText(yamlContent)
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid LinterConfiguration")
+
+        assertEquals(true, config.camelCase)
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with invalid printlnWithoutException value`() {
+        val yamlContent =
+            """
+            printlnWithoutException: "invalid"
+            """.trimIndent()
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText(yamlContent)
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid LinterConfiguration")
+
+        assertEquals(true, config.printlnWithoutExpression)
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with invalid undeclaredVariableStatement value`() {
+        val yamlContent =
+            """
+            undeclaredVariableStatement: "invalid"
+            """.trimIndent()
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText(yamlContent)
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid LinterConfiguration")
+
+        assertEquals(true, config.undeclaredVariableStatement)
+    }
+
+    @Test
+    fun `test readFileAndBuildRules with invalid readInputWithoutExpression value`() {
+        val yamlContent =
+            """
+            readInputWithoutExpression: "invalid"
+            """.trimIndent()
+        val configFile = File(tempDir, "config.yaml")
+        configFile.writeText(yamlContent)
+
+        val result = YamlConfigurationReader.readFileAndBuildRules(configFile)
+
+        assertTrue(result.isSuccess)
+        val config = result.getOrNull() ?: fail("Expected a valid LinterConfiguration")
+
+        assertEquals(true, config.readInputWithoutExpression)
+    }
+}

--- a/parser/src/main/kotlin/parser/ParserDeclarator.kt
+++ b/parser/src/main/kotlin/parser/ParserDeclarator.kt
@@ -2,9 +2,6 @@ package parser
 import ast.AST
 import ast.Conditional
 import ast.Declaration
-import ast.LiteralArgument
-import ast.Range
-import ast.VariableArgument
 import parser.declarator.ConditionalDeclarator
 import parser.declarator.MethodResultDeclarator
 import parser.declarator.VariableDeclarator
@@ -59,7 +56,7 @@ class ParserDeclarator {
     }
 
     private fun parseLiteral(token: TokenInfo.Token): Result<AST> {
-        return Result.success(LiteralArgument(Range(0, 0), token.text, "String"))
+        return Result.failure(Exception("Cannot handle literal: ${token.text}"))
     }
 
     // two cases, as for now
@@ -89,10 +86,10 @@ class ParserDeclarator {
 
     // I don't think you can start with operators If you can't, this method should throw always error.
     private fun parseOperator(token: TokenInfo.Token): Result<AST> {
-        return Result.success(VariableArgument(Range(0, 0), token.text))
+        return Result.failure(Exception("Cannot handle operator: ${token.text}"))
     }
 
     private fun parseSpecial(token: TokenInfo.Token): Result<AST> {
-        return Result.success(VariableArgument(Range(0, 0), token.text))
+        return Result.failure(Exception("Cannot handle special character: ${token.text}"))
     }
 }

--- a/parser/src/test/kotlin/ParserDeclaratorTest.kt
+++ b/parser/src/test/kotlin/ParserDeclaratorTest.kt
@@ -1,0 +1,35 @@
+import factory.LexerFactoryImpl
+import org.junit.jupiter.api.Test
+import parser.MyParser
+import parser.Parser
+
+class ParserDeclaratorTest {
+    private val lexer = LexerFactoryImpl("1.1").create()
+
+    @Test
+    fun `test001 parseByTokenType cannot handle SPECIAL CHARACTER`() {
+        val code = ";"
+        val tokens = lexer.tokenize(code)
+        val parser: Parser = MyParser()
+        val ast = parser.parseTokens(tokens)
+        assert(ast.isFailure)
+    }
+
+    @Test
+    fun `test002 parseByTokenType cannot handle LITERAL`() {
+        val code = "3"
+        val tokens = lexer.tokenize(code)
+        val parser: Parser = MyParser()
+        val ast = parser.parseTokens(tokens)
+        assert(ast.isFailure)
+    }
+
+    @Test
+    fun `test003 parseByTokenType cannot handle OPERATOR`() {
+        val code = "="
+        val tokens = lexer.tokenize(code)
+        val parser: Parser = MyParser()
+        val ast = parser.parseTokens(tokens)
+        assert(ast.isFailure)
+    }
+}


### PR DESCRIPTION
Test: New tests for Parser, Linter, Formatter and AST

Fix: JsonConfigurationReader.kt can only take indents from 0 to 8 now
Fix: when ParserDeclarator.kt recieves types it cannot handle it now returns an error.
Fix: orthography change in ReadEnv.kt

Feat: added hashCode() to ValidResult.kt and WarningResult.kt